### PR TITLE
do not simplify subscript for length 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@taskbase/mathquill-fork",
   "description": "Easily type math in your webapp",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "license": "MPL-2.0",
   "scripts": {
     "build-and-publish": "make && npm publish"

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -246,7 +246,7 @@ var SupSub = P(MathCommand, function(_, super_) {
   _.latex = function() {
     function latex(prefix, block) {
       var l = block && block.latex();
-      return block ? prefix + (l.length === 1 ? l : '{' + (l || ' ') + '}') : '';
+      return block ? prefix + ('{' + (l || ' ') + '}') : '';
     }
     return latex('_', this.sub) + latex('^', this.sup);
   };


### PR DESCRIPTION
Mathquill tries to be too smart. The `l.length === 1` case causes subscripts of length 1 to not be wrapped into brackets. This leads to invalid latex.

Before:

```
\\log _210
```

Now:

```
\\log _{2}10
```

Where the subscript can be properly parsed as `2`.